### PR TITLE
feat: Add possibility to define custom response header

### DIFF
--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -5,12 +5,15 @@ const helpers = require('yeoman-test');
 const helper = require('../generators/app/promptingHelpers');
 const chalk = require('chalk');
 
-describe('generator-http-fake-backend → server', () => {
+describe('generator-http-fake-backend → server with custom header', () => {
   beforeAll(done => {
     helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         serverPort: 8081,
-        apiPrefix: '/api'
+        apiPrefix: '/api',
+        customHeader: true,
+        customHeaderName: 'HeaderName',
+        customHeaderValue: 'HeaderValue'
       })
       .on('end', done);
   });
@@ -31,6 +34,12 @@ describe('generator-http-fake-backend → server', () => {
       });
       it('should contain the prompted api url prefix', () => {
         assert.fileContent('.env', /API_PREFIX=\/api/);
+      });
+      it('should contain the prompted custom header name', () => {
+        assert.fileContent('.env', /CUSTOM_HEADER_NAME=HeaderName/);
+      });
+      it('should contain the prompted custom header value', () => {
+        assert.fileContent('.env', /CUSTOM_HEADER_VALUE=HeaderValue/);
       });
     });
 
@@ -62,6 +71,7 @@ describe('generator-http-fake-backend → server', () => {
     it('should create server files', () => {
       assert.file([
         'server/api/setup/lib/getContentDisposition.js',
+        'server/api/setup/lib/getCustomResponseHeader.js',
         'server/api/setup/index.js',
         'server/api/setup/supportedMethod.js',
         'server/api/setup/unsupportedMethods.js',
@@ -83,6 +93,7 @@ describe('generator-http-fake-backend → server', () => {
         'test/config.js',
         'test/index.js',
         'test/manifest.js',
+        'test/server/api/customResponseHeader.js',
         'test/server/api/endpoint.js',
         'test/server/api/fakeStatusCode.js',
         'test/server/api/fileTypes.js',
@@ -92,6 +103,27 @@ describe('generator-http-fake-backend → server', () => {
         'test/server/api/fixtures/response.txt',
         'test/server/web/index.js'
       ]);
+    });
+  });
+});
+
+describe('generator-http-fake-backend → server without custom header', () => {
+  beforeAll(done => {
+    helpers.run(path.join(__dirname, '../generators/app'))
+      .withPrompts({
+        serverPort: 8081,
+        apiPrefix: '/api',
+        customHeader: false
+      })
+      .on('end', done);
+  });
+
+  describe('.env', () => {
+    it('should contain the prompted custom header name', () => {
+      assert.fileContent('.env', /CUSTOM_HEADER_NAME=\n/);
+    });
+    it('should contain the prompted custom header value', () => {
+      assert.fileContent('.env', /CUSTOM_HEADER_VALUE=\n/);
     });
   });
 });
@@ -106,6 +138,18 @@ describe('generator-http-fake-backend → server → prompting helpers', () => {
     });
     it('should fail when missing a leading slash', () => {
       assert.equal(helper.validateApiPrefix('api'), chalk.red('API prefix has to begin with a `/`.'));
+    });
+  });
+
+  describe('→ validateCustomHeader()', () => {
+    it('should accept a non empty string', () => {
+      assert.equal(helper.validateCustomHeader('x-powered-by'), true);
+    });
+    it('should fail with a empty string', () => {
+      assert.equal(helper.validateCustomHeader(''), chalk.red('Can’t be an empty string.'));
+    });
+    it('should fail with a empty string', () => {
+      assert.equal(helper.validateCustomHeader('   '), chalk.red('Can’t be an empty string.'));
     });
   });
 });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -29,6 +29,27 @@ module.exports = class extends Generator {
         default: '/api',
         store: true,
         validate: helper.validateApiPrefix
+      }, {
+        type: 'confirm',
+        name: 'customHeader',
+        message: 'Would you like to add a custom response header (e.g. Authorization)?',
+        default: false
+      }, {
+        type: 'input',
+        name: 'customHeaderName',
+        message: 'Custom header name:',
+        validate: helper.validateCustomHeader,
+        when(answers) {
+          return answers.customHeader;
+        }
+      }, {
+        type: 'input',
+        name: 'customHeaderValue',
+        message: 'Custom header value:',
+        validate: helper.validateCustomHeader,
+        when(answers) {
+          return answers.customHeader;
+        }
       }
     ];
 
@@ -50,7 +71,9 @@ module.exports = class extends Generator {
       this.templatePath('_env'),
       this.destinationPath('.env'), {
         serverPort: this.props.serverPort,
-        apiPrefix: this.props.apiPrefix
+        apiPrefix: this.props.apiPrefix,
+        customHeaderName: this.props.customHeaderName,
+        customHeaderValue: this.props.customHeaderValue
       }
     );
     this.fs.copy(

--- a/generators/app/promptingHelpers.js
+++ b/generators/app/promptingHelpers.js
@@ -15,4 +15,11 @@ helper.validateApiPrefix = function (value) {
   return returnValue;
 };
 
+helper.validateCustomHeader = function (value) {
+  if (value.trim() === '') {
+    return chalk.red('Can’t be an empty string.');
+  }
+  return true;
+};
+
 module.exports = helper;

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -255,6 +255,10 @@ TEST_PORT=9090
 # eg. http://localhost:8081/api/foo
 API_PREFIX=/api
 
+# Custom response header
+#CUSTOM_HEADER_NAME=Authorization
+#CUSTOM_HEADER_VALUE=Bearer eyJhbGciOiJIUzUxMiJ9
+
 ```
 
 

--- a/generators/app/templates/_env
+++ b/generators/app/templates/_env
@@ -11,3 +11,7 @@ TEST_PORT=9090
 # URL Prefix for the endpoints
 # eg. http://localhost:8081/api/foo
 API_PREFIX=<%= apiPrefix %>
+
+# Custom response header
+CUSTOM_HEADER_NAME=<%= customHeaderName %>
+CUSTOM_HEADER_VALUE=<%= customHeaderValue %>

--- a/generators/app/templates/manifest.js
+++ b/generators/app/templates/manifest.js
@@ -4,6 +4,7 @@ const Confidence = require('confidence');
 const Config = require('./config');
 const Fs = require('fs');
 const Path = require('path');
+const GetCustomResponseHeader = require('./server/api/setup/lib/getCustomResponseHeader');
 
 const criteria = {
     env: process.env.NODE_ENV
@@ -22,7 +23,8 @@ const manifest = {
                 security: true,
                 cors: {
                     origin: ['*'],
-                    credentials: true
+                    credentials: true,
+                    additionalExposedHeaders: [GetCustomResponseHeader(process.env).name]
                 }
             },
             router: {

--- a/generators/app/templates/server/api/setup/lib/getCustomResponseHeader.js
+++ b/generators/app/templates/server/api/setup/lib/getCustomResponseHeader.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (env) {
+
+    return {
+        name: env.CUSTOM_HEADER_NAME || 'X-Powered-By',
+        value: env.CUSTOM_HEADER_VALUE || 'https://hapijs.com'
+    };
+};

--- a/generators/app/templates/server/api/setup/unsupportedMethods.js
+++ b/generators/app/templates/server/api/setup/unsupportedMethods.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Boom = require('boom');
+const CustomResponseHeader = require('./lib/getCustomResponseHeader')(process.env);
 
 module.exports = function (settings, params, path) {
 
@@ -18,6 +19,7 @@ module.exports = function (settings, params, path) {
                 response = Boom.methodNotAllowed();
             }
 
+            response.output.headers[CustomResponseHeader.name] = CustomResponseHeader.value;
             return reply(response);
         }
     };

--- a/generators/app/templates/test/manifest.js
+++ b/generators/app/templates/test/manifest.js
@@ -22,4 +22,10 @@ lab.experiment('Manifest', () => {
         Code.expect(Manifest.meta('/')).to.match(/hapi server config used by glue to compose the server/i);
         done();
     });
+
+    lab.test('it gets the correct custom response header', (done) => {
+
+        Code.expect(Manifest.get('/').server.connections.routes.cors.additionalExposedHeaders).to.equal(['X-Powered-By']);
+        done();
+    });
 });

--- a/generators/app/templates/test/server/api/customResponseHeader.js
+++ b/generators/app/templates/test/server/api/customResponseHeader.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const Lab = require('lab');
+const Code = require('code');
+const Config = require('../../../config');
+const Hapi = require('hapi');
+const SetupEndpoint = require('../../../server/api/setup/');
+const GetCustomResponseHeader = require('../../../server/api/setup/lib/getCustomResponseHeader');
+
+const apiUrlPrefix = Config.get('/apiUrlPrefix');
+
+const Endpoint = SetupEndpoint({
+    name: 'customResponseHeader',
+    urls: [
+        {
+            params: '/regularResponse',
+            requests: [
+                { response: '/test/server/api/fixtures/response.json' }
+            ]
+        },
+        {
+            params: '/fileResponse',
+            requests: [{
+                response: '/test/server/api/fixtures/example.pdf',
+                sendFile: true,
+                mimeType: 'application/pdf'
+            }]
+        },
+        {
+            params: '/boomError',
+            requests: [{ statusCode: 402 }]
+        }
+    ]
+});
+
+const lab = exports.lab = Lab.script();
+let request;
+let server;
+
+lab.beforeEach((done) => {
+
+    const plugins = [Endpoint];
+    server = new Hapi.Server();
+    server.connection({ port: Config.get('/port/web') });
+    server.register(plugins, (err) => {
+
+        if (err) {
+            return done(err);
+        }
+
+        done();
+    });
+});
+
+
+lab.experiment('Custom response header', () => {
+
+    lab.beforeEach((done) => {
+
+
+        done();
+    });
+
+    lab.test('should be read from .env file', (done) => {
+
+        const env = Object.assign({}, process.env);
+
+        env.CUSTOM_HEADER_NAME = 'Authorization';
+        env.CUSTOM_HEADER_VALUE = 'Bearer eyJhbGciOiJIUzUxMiJ9';
+
+        Code.expect(GetCustomResponseHeader(env)).to.equal({
+            name: 'Authorization',
+            value: 'Bearer eyJhbGciOiJIUzUxMiJ9'
+        });
+
+        done();
+    });
+
+    lab.test('should have a fallback if not defined in .env file', (done) => {
+
+
+        Code.expect(GetCustomResponseHeader(process.env)).to.equal({
+            name: 'X-Powered-By',
+            value: 'https://hapijs.com'
+        });
+
+        done();
+    });
+
+    lab.test('regular responses should have the defined response header', (done) => {
+
+        request = {
+            method: 'GET',
+            url: apiUrlPrefix + '/customResponseHeader/regularResponse'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('file responses should have the defined response header', (done) => {
+
+        request = {
+            method: 'GET',
+            url: apiUrlPrefix + '/customResponseHeader/fileResponse'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('boom errors should have the defined response header', (done) => {
+
+        request = {
+            method: 'GET',
+            url: apiUrlPrefix + '/customResponseHeader/boomError'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('unallowed methods of regular responses should have the defined response header', (done) => {
+
+        request = {
+            method: 'POST',
+            url: apiUrlPrefix + '/customResponseHeader/regularResponse'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+    lab.test('unallowed methods of boom errors should have the defined response header', (done) => {
+
+        request = {
+            method: 'POST',
+            url: apiUrlPrefix + '/customResponseHeader/boomError'
+        };
+
+        server.inject(request, (response) => {
+
+            Code.expect(response.headers['x-powered-by']).to.equal('https://hapijs.com');
+
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Closes micromata/http-fake-backend#10

This also can be configured via the new setting in `.env` after generation.